### PR TITLE
Better test coverage

### DIFF
--- a/countrycontinent.go
+++ b/countrycontinent.go
@@ -18,8 +18,10 @@ package countrycontinent
 
 import (
 	"fmt"
-	"strings"
+	"regexp"
 )
+
+var isoCountryCodeRegex = regexp.MustCompile("^[A-Z]{2}$")
 
 // CountryContinent is a struct that holds the country code, country name and continent
 type CountryContinent struct {
@@ -44,6 +46,15 @@ type ContinentNotFoundError struct {
 
 func (e *ContinentNotFoundError) Error() string {
 	return fmt.Sprintf("continent not found: %s", e.Continent)
+}
+
+// InvalidCountryCodeError is returned when a country code is not in the valid format.
+type InvalidCountryCodeError struct {
+	CountryCode string
+}
+
+func (e *InvalidCountryCodeError) Error() string {
+	return fmt.Sprintf("invalid country code format: %s", e.CountryCode)
 }
 
 // countryContinent is a slice of CountryContinent
@@ -295,9 +306,16 @@ func init() {
 	}
 }
 
+// isValidCountryCode checks if the country code is a 2-letter uppercase string.
+func isValidCountryCode(code string) bool {
+	return isoCountryCodeRegex.MatchString(code)
+}
+
 // CountryGetFullName returns the full name of the country with the given country code.
 func CountryGetFullName(countryCode string) (string, error) {
-	countryCode = strings.ToUpper(countryCode)
+	if !isValidCountryCode(countryCode) {
+		return "", &InvalidCountryCodeError{CountryCode: countryCode}
+	}
 	country, ok := countryMap[countryCode]
 	if !ok {
 		return "", &CountryNotFoundError{CountryCode: countryCode}
@@ -307,7 +325,9 @@ func CountryGetFullName(countryCode string) (string, error) {
 
 // CountryGetFullNameContinent returns the full name and continent of the country with the given country code.
 func CountryGetFullNameContinent(countryCode string) (string, string, error) {
-	countryCode = strings.ToUpper(countryCode)
+	if !isValidCountryCode(countryCode) {
+		return "", "", &InvalidCountryCodeError{CountryCode: countryCode}
+	}
 	country, ok := countryMap[countryCode]
 	if !ok {
 		return "", "", &CountryNotFoundError{CountryCode: countryCode}
@@ -317,7 +337,9 @@ func CountryGetFullNameContinent(countryCode string) (string, string, error) {
 
 // CountryGetContinent returns the continent of a country from its country code.
 func CountryGetContinent(countryCode string) (string, error) {
-	countryCode = strings.ToUpper(countryCode)
+	if !isValidCountryCode(countryCode) {
+		return "", &InvalidCountryCodeError{CountryCode: countryCode}
+	}
 	country, ok := countryMap[countryCode]
 	if !ok {
 		return "", &CountryNotFoundError{CountryCode: countryCode}

--- a/countrycontinent_test.go
+++ b/countrycontinent_test.go
@@ -1,6 +1,7 @@
 package countrycontinent
 
 import (
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -9,30 +10,65 @@ import (
 // TestCountryGetFullName tests the CountryGetFullName function.
 func TestCountryGetFullName(t *testing.T) {
 	tests := []struct {
-		name     string
-		code     string
-		expected string
-		wantErr  bool
+		name          string
+		code          string
+		expected      string
+		expectedError error
 	}{
-		{name: "Valid code", code: "US", expected: "United States", wantErr: false},
-		{name: "Invalid code", code: "XX", expected: "", wantErr: true},
-		{name: "Empty code", code: "", expected: "", wantErr: true},
-		{name: "Mixed case code", code: "fr", expected: "France", wantErr: false},
-		{name: "Invalid mixed case code", code: "xx", expected: "", wantErr: true},
-		{name: "Invalid mixed case code", code: "Xx", expected: "", wantErr: true},
-		{name: "Andorra", code: "AD", expected: "Andorra", wantErr: false},
-		{name: "South Africa", code: "ZA", expected: "South Africa", wantErr: false},
-		{name: "Zimbabwe", code: "ZW", expected: "Zimbabwe", wantErr: false},
+		{name: "Valid code US", code: "US", expected: "United States", expectedError: nil},
+		{name: "Unknown code XX", code: "XX", expected: "", expectedError: &CountryNotFoundError{CountryCode: "XX"}},
+		{name: "Empty code", code: "", expected: "", expectedError: &InvalidCountryCodeError{CountryCode: ""}},
+		{name: "Lowercase code fr", code: "fr", expected: "", expectedError: &InvalidCountryCodeError{CountryCode: "fr"}},
+		{name: "Lowercase code xx", code: "xx", expected: "", expectedError: &InvalidCountryCodeError{CountryCode: "xx"}},
+		{name: "Mixed case code Xx", code: "Xx", expected: "", expectedError: &InvalidCountryCodeError{CountryCode: "Xx"}},
+		{name: "Valid code AD", code: "AD", expected: "Andorra", expectedError: nil},
+		{name: "Valid code ZA", code: "ZA", expected: "South Africa", expectedError: nil},
+		{name: "Valid code ZW", code: "ZW", expected: "Zimbabwe", expectedError: nil},
+		{name: "Invalid format - too short", code: "A", expected: "", expectedError: &InvalidCountryCodeError{CountryCode: "A"}},
+		{name: "Invalid format - too long", code: "USA", expected: "", expectedError: &InvalidCountryCodeError{CountryCode: "USA"}},
+		{name: "Invalid format - contains number", code: "U1", expected: "", expectedError: &InvalidCountryCodeError{CountryCode: "U1"}},
+		{name: "Invalid format - contains special char", code: "U@", expected: "", expectedError: &InvalidCountryCodeError{CountryCode: "U@"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := CountryGetFullName(tc.code)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("CountryGetFullName(%s) error = %v, wantErr %v", tc.code, err, tc.wantErr)
-				return
+			if !reflect.DeepEqual(err, tc.expectedError) {
+				t.Errorf("CountryGetFullName(%s) error = %v, wantError %v", tc.code, err, tc.expectedError)
 			}
-			if got != tc.expected {
+			if err == nil && got != tc.expected { // Only check 'got' if no error was expected
 				t.Errorf("CountryGetFullName(%s) got = %v, want %v", tc.code, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestErrorMessages(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "InvalidCountryCodeError",
+			err:      &InvalidCountryCodeError{CountryCode: "XX"},
+			expected: "invalid country code format: XX",
+		},
+		{
+			name:     "CountryNotFoundError",
+			err:      &CountryNotFoundError{CountryCode: "YY"},
+			expected: "country code not found: YY",
+		},
+		{
+			name:     "ContinentNotFoundError",
+			err:      &ContinentNotFoundError{Continent: "Mars"},
+			expected: "continent not found: Mars",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.err.Error() != tc.expected {
+				t.Errorf("Error() got %q, want %q", tc.err.Error(), tc.expected)
 			}
 		})
 	}
@@ -44,28 +80,33 @@ func TestCountryGetFullNameContinent(t *testing.T) {
 		code          string
 		wantCountry   string
 		wantContinent string
-		wantErr       bool
+		expectedError error
 	}{
-		{name: "Valid code", code: "NL", wantCountry: "Netherlands", wantContinent: "Europe", wantErr: false},
-		{name: "Valid code", code: "US", wantCountry: "United States", wantContinent: "North America", wantErr: false},
-		{name: "Valid code", code: "MX", wantCountry: "Mexico", wantContinent: "North America", wantErr: false},
-		{name: "Valid code", code: "PE", wantCountry: "Peru", wantContinent: "South America", wantErr: false},
-		{name: "Valid code", code: "DM", wantCountry: "Dominica", wantContinent: "Caribbean", wantErr: false},
-		{name: "Valid code", code: "NZ", wantCountry: "New Zealand (Aotearoa)", wantContinent: "Oceania", wantErr: false},
-		{name: "Valid code", code: "JP", wantCountry: "Japan", wantContinent: "Asia", wantErr: false},
-		{name: "Invalid code", code: "XX", wantCountry: "", wantContinent: "", wantErr: true},
-		{name: "Andorra", code: "AD", wantCountry: "Andorra", wantContinent: "Europe", wantErr: false},
-		{name: "South Africa", code: "ZA", wantCountry: "South Africa", wantContinent: "Africa", wantErr: false},
-		{name: "Zimbabwe", code: "ZW", wantCountry: "Zimbabwe", wantContinent: "Africa", wantErr: false},
+		{name: "Valid code NL", code: "NL", wantCountry: "Netherlands", wantContinent: "Europe", expectedError: nil},
+		{name: "Valid code US", code: "US", wantCountry: "United States", wantContinent: "North America", expectedError: nil},
+		{name: "Valid code MX", code: "MX", wantCountry: "Mexico", wantContinent: "North America", expectedError: nil},
+		{name: "Valid code PE", code: "PE", wantCountry: "Peru", wantContinent: "South America", expectedError: nil},
+		{name: "Valid code DM", code: "DM", wantCountry: "Dominica", wantContinent: "Caribbean", expectedError: nil},
+		{name: "Valid code NZ", code: "NZ", wantCountry: "New Zealand (Aotearoa)", wantContinent: "Oceania", expectedError: nil},
+		{name: "Valid code JP", code: "JP", wantCountry: "Japan", wantContinent: "Asia", expectedError: nil},
+		{name: "Unknown code XX", code: "XX", wantCountry: "", wantContinent: "", expectedError: &CountryNotFoundError{CountryCode: "XX"}},
+		{name: "Valid code AD", code: "AD", wantCountry: "Andorra", wantContinent: "Europe", expectedError: nil},
+		{name: "Valid code ZA", code: "ZA", wantCountry: "South Africa", wantContinent: "Africa", expectedError: nil},
+		{name: "Valid code ZW", code: "ZW", wantCountry: "Zimbabwe", wantContinent: "Africa", expectedError: nil},
+		{name: "Empty code", code: "", wantCountry: "", wantContinent: "", expectedError: &InvalidCountryCodeError{CountryCode: ""}},
+		{name: "Lowercase code fr", code: "fr", wantCountry: "", wantContinent: "", expectedError: &InvalidCountryCodeError{CountryCode: "fr"}},
+		{name: "Invalid format - too short", code: "A", wantCountry: "", wantContinent: "", expectedError: &InvalidCountryCodeError{CountryCode: "A"}},
+		{name: "Invalid format - too long", code: "USA", wantCountry: "", wantContinent: "", expectedError: &InvalidCountryCodeError{CountryCode: "USA"}},
+		{name: "Invalid format - contains number", code: "U1", wantCountry: "", wantContinent: "", expectedError: &InvalidCountryCodeError{CountryCode: "U1"}},
+		{name: "Invalid format - contains special char", code: "U@", wantCountry: "", wantContinent: "", expectedError: &InvalidCountryCodeError{CountryCode: "U@"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			gotCountry, gotContinent, err := CountryGetFullNameContinent(tc.code)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("CountryGetFullNameContinent(%s) error = %v, wantErr %v", tc.code, err, tc.wantErr)
-				return
+			if !reflect.DeepEqual(err, tc.expectedError) {
+				t.Errorf("CountryGetFullNameContinent(%s) error = %v, wantError %v", tc.code, err, tc.expectedError)
 			}
-			if gotCountry != tc.wantCountry || gotContinent != tc.wantContinent {
+			if err == nil && (gotCountry != tc.wantCountry || gotContinent != tc.wantContinent) {
 				t.Errorf("CountryGetFullNameContinent(%s) = %s, %s; want %s, %s", tc.code, gotCountry, gotContinent, tc.wantCountry, tc.wantContinent)
 			}
 		})
@@ -116,31 +157,36 @@ func TestContinentGetCountries(t *testing.T) {
 
 func TestCountryGetContinent(t *testing.T) {
 	tests := []struct {
-		name    string
-		code    string
-		want    string
-		wantErr bool
+		name          string
+		code          string
+		want          string
+		expectedError error
 	}{
-		{name: "Valid code", code: "NL", want: "Europe", wantErr: false},
-		{name: "Valid code", code: "US", want: "North America", wantErr: false},
-		{name: "Valid code", code: "MX", want: "North America", wantErr: false},
-		{name: "Valid code", code: "PE", want: "South America", wantErr: false},
-		{name: "Valid code", code: "DM", want: "Caribbean", wantErr: false},
-		{name: "Valid code", code: "NZ", want: "Oceania", wantErr: false},
-		{name: "Valid code", code: "JP", want: "Asia", wantErr: false},
-		{name: "Invalid code", code: "XX", want: "", wantErr: true},
-		{name: "Andorra", code: "AD", want: "Europe", wantErr: false},
-		{name: "South Africa", code: "ZA", want: "Africa", wantErr: false},
-		{name: "Zimbabwe", code: "ZW", want: "Africa", wantErr: false},
+		{name: "Valid code NL", code: "NL", want: "Europe", expectedError: nil},
+		{name: "Valid code US", code: "US", want: "North America", expectedError: nil},
+		{name: "Valid code MX", code: "MX", want: "North America", expectedError: nil},
+		{name: "Valid code PE", code: "PE", want: "South America", expectedError: nil},
+		{name: "Valid code DM", code: "DM", want: "Caribbean", expectedError: nil},
+		{name: "Valid code NZ", code: "NZ", want: "Oceania", expectedError: nil},
+		{name: "Valid code JP", code: "JP", want: "Asia", expectedError: nil},
+		{name: "Unknown code XX", code: "XX", want: "", expectedError: &CountryNotFoundError{CountryCode: "XX"}},
+		{name: "Valid code AD", code: "AD", want: "Europe", expectedError: nil},
+		{name: "Valid code ZA", code: "ZA", want: "Africa", expectedError: nil},
+		{name: "Valid code ZW", code: "ZW", want: "Africa", expectedError: nil},
+		{name: "Empty code", code: "", want: "", expectedError: &InvalidCountryCodeError{CountryCode: ""}},
+		{name: "Lowercase code fr", code: "fr", want: "", expectedError: &InvalidCountryCodeError{CountryCode: "fr"}},
+		{name: "Invalid format - too short", code: "A", want: "", expectedError: &InvalidCountryCodeError{CountryCode: "A"}},
+		{name: "Invalid format - too long", code: "USA", want: "", expectedError: &InvalidCountryCodeError{CountryCode: "USA"}},
+		{name: "Invalid format - contains number", code: "U1", want: "", expectedError: &InvalidCountryCodeError{CountryCode: "U1"}},
+		{name: "Invalid format - contains special char", code: "U@", want: "", expectedError: &InvalidCountryCodeError{CountryCode: "U@"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := CountryGetContinent(tc.code)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("CountryGetContinent(%s) error = %v, wantErr %v", tc.code, err, tc.wantErr)
-				return
+			if !reflect.DeepEqual(err, tc.expectedError) {
+				t.Errorf("CountryGetContinent(%s) error = %v, wantError %v", tc.code, err, tc.expectedError)
 			}
-			if got != tc.want {
+			if err == nil && got != tc.want {
 				t.Errorf("CountryGetContinent(%s) = %s; want %s", tc.code, got, tc.want)
 			}
 		})
@@ -183,4 +229,32 @@ func equalSlices(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestIsValidCountryCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{name: "Valid code - US", code: "US", expected: true},
+		{name: "Valid code - DE", code: "DE", expected: true},
+		{name: "Invalid code - empty", code: "", expected: false},
+		{name: "Invalid code - too short", code: "A", expected: false},
+		{name: "Invalid code - too long", code: "USA", expected: false},
+		{name: "Invalid code - lowercase", code: "us", expected: false},
+		{name: "Invalid code - mixed case", code: "Us", expected: false},
+		{name: "Invalid code - contains number", code: "U1", expected: false},
+		{name: "Invalid code - contains special character", code: "U@", expected: false},
+		{name: "Invalid code - number only", code: "12", expected: false},
+		{name: "Invalid code - special chars only", code: "@#", expected: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isValidCountryCode(tc.code)
+			if got != tc.expected {
+				t.Errorf("isValidCountryCode(%q) = %v, want %v", tc.code, got, tc.expected)
+			}
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/demoulin/countrycontinent/v1.5.1
 
-go 1.22
+go 1.22.2


### PR DESCRIPTION
Introduced a new test suite called `TestErrorMessages` specifically to cover the `Error()` methods of our custom error types. This includes:
- InvalidCountryCodeError
- CountryNotFoundError
- ContinentNotFoundError